### PR TITLE
Change 'Produtos' to 'Insumos' throughout the system and add 'Categor…

### DIFF
--- a/src/app/configuracoes/page.tsx
+++ b/src/app/configuracoes/page.tsx
@@ -46,6 +46,13 @@ interface Categoria {
   ativa: boolean
 }
 
+interface CategoriaInsumo {
+  id: string
+  nome: string
+  descricao: string
+  ativa: boolean
+}
+
 interface UnidadeMedida {
   id: string
   nome: string
@@ -75,6 +82,13 @@ export default function ConfiguracoesPage() {
     { id: '4', nome: 'Grama', simbolo: 'g', tipo: 'Peso' }
   ])
 
+  const [categoriasInsumos, setCategoriasInsumos] = useState<CategoriaInsumo[]>([
+    { id: '1', nome: 'Farinhas', descricao: 'Farinhas e derivados', ativa: true },
+    { id: '2', nome: 'Açúcares', descricao: 'Açúcares e adoçantes', ativa: true },
+    { id: '3', nome: 'Chocolates', descricao: 'Chocolates e cacau', ativa: true },
+    { id: '4', nome: 'Laticínios', descricao: 'Leites, queijos e derivados', ativa: true }
+  ])
+
   const [usuarios, setUsuarios] = useState<Usuario[]>([
     { id: '1', nome: 'Administrador', email: 'admin@sistemachef.com', role: 'admin', ativo: true },
     { id: '2', nome: 'Editor', email: 'editor@sistemachef.com', role: 'editor', ativo: true },
@@ -82,7 +96,7 @@ export default function ConfiguracoesPage() {
   ])
 
   const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const [dialogType, setDialogType] = useState<'categoria' | 'unidade' | 'usuario'>('categoria')
+  const [dialogType, setDialogType] = useState<'categoria' | 'categoria-insumo' | 'unidade' | 'usuario'>('categoria')
 
   const getRoleColor = (role: string) => {
     switch (role) {
@@ -122,6 +136,7 @@ export default function ConfiguracoesPage() {
             <DialogHeader>
               <DialogTitle>
                 {dialogType === 'categoria' && 'Nova Categoria'}
+                {dialogType === 'categoria-insumo' && 'Nova Categoria de Insumo'}
                 {dialogType === 'unidade' && 'Nova Unidade de Medida'}
                 {dialogType === 'usuario' && 'Novo Usuário'}
               </DialogTitle>
@@ -139,6 +154,19 @@ export default function ConfiguracoesPage() {
                   <div className="space-y-2">
                     <Label htmlFor="desc-cat">Descrição</Label>
                     <Input id="desc-cat" placeholder="Descrição da categoria" />
+                  </div>
+                </>
+              )}
+
+              {dialogType === 'categoria-insumo' && (
+                <>
+                  <div className="space-y-2">
+                    <Label htmlFor="nome-cat-insumo">Nome da Categoria</Label>
+                    <Input id="nome-cat-insumo" placeholder="Ex: Farinhas" />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="desc-cat-insumo">Descrição</Label>
+                    <Input id="desc-cat-insumo" placeholder="Descrição da categoria de insumo" />
                   </div>
                 </>
               )}
@@ -195,6 +223,7 @@ export default function ConfiguracoesPage() {
       <Tabs defaultValue="categorias" className="space-y-4">
         <TabsList>
           <TabsTrigger value="categorias">Categorias de Receitas</TabsTrigger>
+          <TabsTrigger value="categorias-insumos">Categorias de Insumos</TabsTrigger>
           <TabsTrigger value="unidades">Unidades de Medida</TabsTrigger>
           <TabsTrigger value="usuarios">Usuários</TabsTrigger>
         </TabsList>
@@ -248,6 +277,55 @@ export default function ConfiguracoesPage() {
           </Card>
         </TabsContent>
 
+        <TabsContent value="categorias-insumos" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Tag className="h-5 w-5" />
+                Categorias de Insumos ({categoriasInsumos.length})
+              </CardTitle>
+              <CardDescription>
+                Gerencie as categorias para organizar seus insumos
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Nome</TableHead>
+                    <TableHead>Descrição</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Ações</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {categoriasInsumos.map((categoria) => (
+                    <TableRow key={categoria.id}>
+                      <TableCell className="font-medium">{categoria.nome}</TableCell>
+                      <TableCell>{categoria.descricao}</TableCell>
+                      <TableCell>
+                        <Badge variant={categoria.ativa ? 'default' : 'secondary'}>
+                          {categoria.ativa ? 'Ativa' : 'Inativa'}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end space-x-2">
+                          <Button variant="outline" size="sm">
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                          <Button variant="outline" size="sm" className="text-destructive">
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
         <TabsContent value="unidades" className="space-y-4">
           <Card>
             <CardHeader>
@@ -256,7 +334,7 @@ export default function ConfiguracoesPage() {
                 Unidades de Medida ({unidades.length})
               </CardTitle>
               <CardDescription>
-                Gerencie as unidades de medida para ingredientes e produtos
+                Gerencie as unidades de medida para ingredientes e insumos
               </CardDescription>
             </CardHeader>
             <CardContent>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -50,7 +50,7 @@ export default function DashboardPage() {
     }
   ]
 
-  const produtosBaixoEstoque = [
+  const insumosBaixoEstoque = [
     {
       id: '1',
       nome: 'Chocolate em Pó',
@@ -120,7 +120,7 @@ export default function DashboardPage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
-              Produtos em Estoque
+              Insumos em Estoque
             </CardTitle>
             <Package className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
@@ -218,13 +218,13 @@ export default function DashboardPage() {
                     Estoque Baixo
                   </p>
                   <p className="text-sm text-muted-foreground">
-                    {produtosBaixoEstoque.length} itens com estoque baixo
+                    {insumosBaixoEstoque.length} itens com estoque baixo
                   </p>
                 </div>
               </div>
               
               <div className="space-y-2">
-                {produtosBaixoEstoque.map((produto) => (
+                {insumosBaixoEstoque.map((produto) => (
                   <div key={produto.id} className="flex items-center justify-between text-sm">
                     <span>{produto.nome}</span>
                     <Badge variant="destructive">

--- a/src/app/estoque/page.tsx
+++ b/src/app/estoque/page.tsx
@@ -82,7 +82,7 @@ export default function EstoquePage() {
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Controle de Estoque</h1>
           <p className="text-muted-foreground">
-            Gerencie entradas e saídas de produtos
+            Gerencie entradas e saídas de insumos
           </p>
         </div>
         <div className="flex space-x-2">
@@ -154,14 +154,14 @@ export default function EstoquePage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
-              Total de Produtos
+              Total de Insumos
             </CardTitle>
             <Package className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">24</div>
             <p className="text-xs text-muted-foreground">
-              Produtos cadastrados
+              Insumos cadastrados
             </p>
           </CardContent>
         </Card>

--- a/src/app/precos/page.tsx
+++ b/src/app/precos/page.tsx
@@ -166,14 +166,14 @@ export default function PrecosPage() {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">
-              Produtos Precificados
+              Insumos Precificados
             </CardTitle>
             <DollarSign className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{precos.length}</div>
             <p className="text-xs text-muted-foreground">
-              Produtos com preço definido
+              Insumos com preço definido
             </p>
           </CardContent>
         </Card>
@@ -280,7 +280,7 @@ export default function PrecosPage() {
           <CardHeader>
             <CardTitle>Preços Configurados ({precos.length})</CardTitle>
             <CardDescription>
-              Lista de produtos com preços definidos
+              Lista de insumos com preços definidos
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/src/app/produtos/page.tsx
+++ b/src/app/produtos/page.tsx
@@ -99,7 +99,7 @@ export default function ProdutosPage() {
     <DashboardLayout>
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Produtos</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Insumos</h1>
           <p className="text-muted-foreground">
             Gerencie seus insumos e ingredientes
           </p>
@@ -108,20 +108,20 @@ export default function ProdutosPage() {
           <DialogTrigger asChild>
             <Button>
               <Plus className="mr-2 h-4 w-4" />
-              Novo Produto
+              Novo Insumo
             </Button>
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>
-              <DialogTitle>Novo Produto</DialogTitle>
+              <DialogTitle>Novo Insumo</DialogTitle>
               <DialogDescription>
-                Cadastre um novo produto/insumo
+                Cadastre um novo insumo
               </DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4">
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-2">
-                  <Label htmlFor="nome">Nome do Produto</Label>
+                  <Label htmlFor="nome">Nome do Insumo</Label>
                   <Input id="nome" placeholder="Ex: Farinha de Trigo" />
                 </div>
                 <div className="space-y-2">
@@ -148,7 +148,7 @@ export default function ProdutosPage() {
                   Cancelar
                 </Button>
                 <Button onClick={() => setIsDialogOpen(false)}>
-                  Cadastrar Produto
+                  Cadastrar Insumo
                 </Button>
               </div>
             </div>
@@ -161,7 +161,7 @@ export default function ProdutosPage() {
           <CardHeader>
             <CardTitle>Filtros</CardTitle>
             <CardDescription>
-              Encontre rapidamente seus produtos
+              Encontre rapidamente seus insumos
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -179,9 +179,9 @@ export default function ProdutosPage() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Produtos ({filteredProdutos.length})</CardTitle>
+            <CardTitle>Insumos ({filteredProdutos.length})</CardTitle>
             <CardDescription>
-              Lista de todos os produtos cadastrados
+              Lista de todos os insumos cadastrados
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -22,7 +22,7 @@ import {
 const navigation = [
   { name: 'Dashboard', href: '/dashboard', icon: Home },
   { name: 'Fichas Técnicas', href: '/fichas-tecnicas', icon: FileText },
-  { name: 'Produtos', href: '/produtos', icon: ChefHat },
+  { name: 'Insumos', href: '/produtos', icon: ChefHat },
   { name: 'Estoque', href: '/estoque', icon: Package },
   { name: 'Produção', href: '/producao', icon: Factory },
   { name: 'Preços', href: '/precos', icon: DollarSign },


### PR DESCRIPTION
…ias de Insumos' configuration

- Updated sidebar navigation from 'Produtos' to 'Insumos'
- Changed all page titles, descriptions, and UI text from 'Produtos' to 'Insumos'
- Added 'Categorias de Insumos' tab to configurations page with full functionality
- Updated variable names and references in dashboard (produtosBaixoEstoque -> insumosBaixoEstoque)
- Modified button text, dialog titles, and form labels to use 'Insumos' terminology
- Updated descriptions in precos, estoque, and configuracoes pages
- All functionality remains intact with new terminology